### PR TITLE
Fix schematic cannon requiring duplicate machine items

### DIFF
--- a/src/main/java/fr/frinn/custommachinerycreate/mixin/CustomMachineBlockMixin.java
+++ b/src/main/java/fr/frinn/custommachinerycreate/mixin/CustomMachineBlockMixin.java
@@ -1,20 +1,25 @@
 package fr.frinn.custommachinerycreate.mixin;
 
+import com.simibubi.create.api.schematic.requirement.SpecialBlockItemRequirement;
 import com.simibubi.create.content.kinetics.base.IRotate;
+import com.simibubi.create.content.schematics.requirement.ItemRequirement;
 import fr.frinn.custommachinery.api.machine.MachineTile;
 import fr.frinn.custommachinery.common.init.CustomMachineBlock;
+import fr.frinn.custommachinery.common.init.CustomMachineItem;
 import fr.frinn.custommachinerycreate.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 
 import java.util.Optional;
 
 @Mixin(CustomMachineBlock.class)
-public abstract class CustomMachineBlockMixin implements IRotate {
+public abstract class CustomMachineBlockMixin implements IRotate, SpecialBlockItemRequirement {
     @Override
     public boolean hasShaftTowards(LevelReader world, BlockPos pos, BlockState state, Direction face) {
         return Optional.ofNullable(world.getBlockEntity(pos))
@@ -27,5 +32,15 @@ public abstract class CustomMachineBlockMixin implements IRotate {
     @Override
     public Axis getRotationAxis(BlockState state) {
         return Axis.Y;
+    }
+
+    @Override
+    public ItemRequirement getRequiredItems(BlockState state, @Nullable BlockEntity blockEntity) {
+        if (blockEntity instanceof MachineTile machine) {
+            return new ItemRequirement(new ItemRequirement.StrictNbtStackRequirement(
+                    CustomMachineItem.makeMachineItem(machine.getMachine().getId()), ItemRequirement.ItemUseType.CONSUME));
+        } else {
+            return ItemRequirement.INVALID;
+        }
     }
 }

--- a/src/main/java/fr/frinn/custommachinerycreate/mixin/MachineTileMixin.java
+++ b/src/main/java/fr/frinn/custommachinerycreate/mixin/MachineTileMixin.java
@@ -3,24 +3,19 @@ package fr.frinn.custommachinerycreate.mixin;
 import com.simibubi.create.api.equipment.goggles.IHaveGoggleInformation;
 import com.simibubi.create.api.equipment.goggles.IHaveHoveringInformation;
 import com.simibubi.create.api.schematic.nbt.PartialSafeNBT;
-import com.simibubi.create.api.schematic.requirement.SpecialBlockEntityItemRequirement;
-import com.simibubi.create.content.schematics.requirement.ItemRequirement;
-import com.simibubi.create.content.schematics.requirement.ItemRequirement.ItemUseType;
 import fr.frinn.custommachinery.api.machine.ICustomMachine;
 import fr.frinn.custommachinery.api.machine.MachineTile;
-import fr.frinn.custommachinery.common.init.CustomMachineItem;
 import fr.frinn.custommachinerycreate.Registration;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 import java.util.List;
 
 @Mixin(MachineTile.class)
-public abstract class MachineTileMixin implements IHaveGoggleInformation, IHaveHoveringInformation, PartialSafeNBT, SpecialBlockEntityItemRequirement {
+public abstract class MachineTileMixin implements IHaveGoggleInformation, IHaveHoveringInformation, PartialSafeNBT {
 
     @Shadow(remap = false)
     public abstract ICustomMachine getMachine();
@@ -44,10 +39,5 @@ public abstract class MachineTileMixin implements IHaveGoggleInformation, IHaveH
     @Override
     public void writeSafe(CompoundTag nbt, HolderLookup.Provider registries) {
         nbt.putString("machineID", this.getMachine().getId().toString());
-    }
-
-    @Override
-    public ItemRequirement getRequiredItems(BlockState state) {
-        return new ItemRequirement(new ItemRequirement.StrictNbtStackRequirement(CustomMachineItem.makeMachineItem(this.getMachine().getId()), ItemUseType.CONSUME));
     }
 }


### PR DESCRIPTION
_The following content was machine-translated and may contain inaccuracies._

This PR fixes an issue where schematic cannon material requirements could be calculated incorrectly, causing an extra copy of the machine item to be requested during schematic printing.

### Root Cause

The compatibility implementation used `ISpecialBlockEntityItemRequirement` to define the material requirements of custom machines.

However, according to Create's requirement resolution logic, `SpecialBlockItemRequirement` and `SpecialBlockEntityItemRequirement` serve different purposes:

* `SpecialBlockItemRequirement` defines the **base item requirements** needed to place a block.
* `SpecialBlockEntityItemRequirement` defines **additional requirements** contributed by block entity data.

The relevant code from Create first collects block requirements and then unions block entity requirements:
[ItemRequirement.java#L69](https://github.com/Creators-of-Create/Create/blob/03ce9a27a7d19211978cf2ca78114349a83f1870/src/main/java/com/simibubi/create/content/schematics/requirement/ItemRequirement.java#L69)
```java
if (block instanceof SpecialBlockItemRequirement specialBlock) {
	requirement = specialBlock.getRequiredItems(state, be);
} else {
	requirement = defaultOf(state, be);
}

...

if (be instanceof SpecialBlockEntityItemRequirement specialBE) {
    requirement = requirement.union(specialBE.getRequiredItems(state));
}
```

A typical example is a Brass Funnel:

* The Brass Funnel item itself is provided through `SpecialBlockItemRequirement`.
* Additional data, such as filter items stored in the block entity, is provided through `SpecialBlockEntityItemRequirement`.

[SmartBlockEntity.java#L195](https://github.com/Creators-of-Create/Create/blob/03ce9a27a7d19211978cf2ca78114349a83f1870/src/main/java/com/simibubi/create/foundation/blockEntity/SmartBlockEntity.java#L195)
```java
public ItemRequirement getRequiredItems(BlockState state) {
	return getAllBehaviours().stream()
		.reduce(ItemRequirement.NONE, (r, b) -> r.union(b.getRequiredItems()), ItemRequirement::union);
}
```

Because Custom Machinery defined the machine's primary material requirement through `ISpecialBlockEntityItemRequirement`, Create treated it as an additional requirement and merged it with the normal block requirement calculation. In certain situations, this caused the schematic cannon to request an extra copy of the machine item.
